### PR TITLE
fixes jifty writeccjs that writes log messages to storable file

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,6 +53,7 @@ requires('Hash::Merge', '0.12');
 requires('Hash::MultiValue', 0.05);
 requires('IO::Handle::Util');
 requires('IPC::PubSub' => '0.23' );
+requires('IPC::Run::SafeHandles');
 requires('IPC::Run3');
 requires('Jifty::DBI' => '0.68' );            # Jifty::DBI::Collection Jifty::DBI::Handle Jifty::DBI::Record::Cachable Jifty::DBI::SchemaGenerator
 requires('JSON' => 2.17);

--- a/lib/Jifty/Plugin/CompressedCSSandJS.pm
+++ b/lib/Jifty/Plugin/CompressedCSSandJS.pm
@@ -5,6 +5,7 @@ package Jifty::Plugin::CompressedCSSandJS;
 use base 'Jifty::Plugin';
 
 use IPC::Run3 'run3';
+use IPC::Run::SafeHandles;
 use IO::Handle ();
 use Plack::Util;
 use HTTP::Message::PSGI;
@@ -237,17 +238,6 @@ sub minify_js {
     my ($output, $err);
 
     $self->log->debug("Minifying JS...");
-
-    # We need to reopen stdout temporarily, because in FCGI
-    # environment, stdout is tied to FCGI::Stream, and the child
-    # of the run3 wouldn't be able to reopen STDOUT properly.
-    my $stdout = IO::Handle->new;
-    $stdout->fdopen( 1, 'w' );
-    local *STDOUT = $stdout;
-
-    my $stderr = IO::Handle->new;
-    $stderr->fdopen( 2, 'w' );
-    local *STDERR = $stderr;
 
     local $SIG{'CHLD'} = 'DEFAULT';
     run3 [$self->jsmin], $input, \$output, \$err;


### PR DESCRIPTION
when the log messages are buffered in stdout, they get flushed to IPC::Run3's output somehow.  use IPC::Run::SafeHandles to wrap ipc::run3 only when required.
